### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: ['main']
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Never run two FTP syncs at once — it corrupts the deploy state.
 concurrency:
   group: deploy


### PR DESCRIPTION
Potential fix for [https://github.com/arnonrdp/Portfolio/security/code-scanning/3](https://github.com/arnonrdp/Portfolio/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults. The best minimal fix here is to set:

- `contents: read`

at the workflow root (applies to all jobs unless overridden). This preserves current behavior while enforcing least privilege and satisfying CodeQL.

**Where to change:** `.github/workflows/deploy.yml`, immediately after the `on:` block (before `concurrency:` is clean and conventional).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
